### PR TITLE
Fix variable name in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ You can start the hot loader server by:
 ```ts
 import * as ng2HotLoader from 'angular2-hot-loader';
 
-ng2hotloader.listen({
+ng2HotLoader.listen({
   port: 4412,
   projectRoot: __dirname
 });


### PR DESCRIPTION
The lowercase variable 'ng2hotloader' in the README needs to be camel case for the example to work since it was imported as 'ng2HotLoader' on line 18. 